### PR TITLE
Add tilde to AutoROM version specifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(
             "opencv-python",
             # For atari games,
             "ale-py~=0.7.4",
-            "autorom=0.5.5",
+            "autorom~=0.5.5",
             "pillow",
             # Tensorboard support
             "tensorboard>=2.2.0",


### PR DESCRIPTION
## Description
This pull request adds a tilde for the operator to ensure AutoROM is at least version 0.5.5 but stays in the version 0.5.* family.